### PR TITLE
Chore: herokuデプロイのため設定を追記#11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.8)
     oauth2 (1.4.7)
       faraday (>= 0.8, < 2.0)
@@ -365,6 +367,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   annotate


### PR DESCRIPTION
## 概要
herokuへのデプロイのため、 a226e54 にて`bundle lock --add-platform x86_64-linux`を実行し、プラットフォームの設定を追記。
