### PR TITLE
Feat: 多対多のモデル間で関連付け出来る数を制限する

### DIFF
--- a/app/controllers/whiskeys_controller.rb
+++ b/app/controllers/whiskeys_controller.rb
@@ -66,6 +66,6 @@ class WhiskeysController < ApplicationController
     # Only allow a list of trusted parameters through.
     def whiskey_params
       # params.fetch(:whiskey, {})
-      params.require(:whiskey).permit(:name, :description, :feeling_to_whiskey_with_tongue, :flavor_strength, :rarity, :reasonable_price, flavor_ids: [], :flavor_id)
+      params.require(:whiskey).permit(:name, :description, :feeling_to_whiskey_with_tongue, :flavor_strength, :rarity, :reasonable_price, :drink_way_id, flavor_ids: [])
     end
 end

--- a/app/models/whiskey.rb
+++ b/app/models/whiskey.rb
@@ -33,6 +33,8 @@ class Whiskey < ApplicationRecord
   validates :flavor_strength, presence: true
   validates :rarity, presence: true
 
+  validates :whiskey_flavors, length: { maximum: 3, message: 'は1ウイスキーにつき3つまでじゃよ。欲張りなさんな。'}
+
   enum feeling_to_whiskey_with_tongue: { light: 0, a_little_light: 1, balanced: 2, a_little_rich: 3, rich: 4 }
   enum flavor_strength: { delicate: 0, a_little_delicate: 1, normal: 2, a_little_smoky: 3, smoky: 4 }
   enum rarity: { rare: 0, a_little_rare: 1, stable_supplyed: 2 }

--- a/app/models/whiskey.rb
+++ b/app/models/whiskey.rb
@@ -33,7 +33,7 @@ class Whiskey < ApplicationRecord
   validates :flavor_strength, presence: true
   validates :rarity, presence: true
 
-  validates :whiskey_flavors, length: { maximum: 3, message: 'は1ウイスキーにつき3つまでじゃよ。欲張りなさんな。'}
+  validates :whiskey_flavors, length: { maximum: 3, message: I18n.t('activerecord.errors.messages.a_whiskey_has_upto_three_flavors') }
 
   enum feeling_to_whiskey_with_tongue: { light: 0, a_little_light: 1, balanced: 2, a_little_rich: 3, rich: 4 }
   enum flavor_strength: { delicate: 0, a_little_delicate: 1, normal: 2, a_little_smoky: 3, smoky: 4 }

--- a/app/views/whiskeys/_form.html.erb
+++ b/app/views/whiskeys/_form.html.erb
@@ -43,6 +43,6 @@
     <%= f.collection_select :drink_way_id, DrinkWay.all, :id, :name, class: 'form-control' %>
   </div>
   <div class="actions">
-    <%= f.submit 'ログイン' %>
+    <%= f.submit '作成' %>
   </div>
 <% end %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -7,6 +7,7 @@ ja:
       whiskey: ウイスキー
       flavor: フレーバー
       drink_way: 飲み方
+      whyskey_flavors: ウイスキーのフレーバー
     attributes:
       id: ID
       created_at: 作成日時
@@ -22,6 +23,7 @@ ja:
         reasonable_price: 適正価格
         flavor_id: フレーバー
         drink_way_id: 飲み方
+        whiskey_flavors: ウイスキーのフレーバー
       flavor:
         name: 名称
         detail: 詳細説明
@@ -30,6 +32,10 @@ ja:
         name: 名称
         how_to_make: 作り方
         explanation: 説明
+    errors:
+      messages:
+        a_whiskey_has_upto_three_flavors: は3つまでじゃよ。欲張りなさんな。
+
 
   enums:
     user:


### PR DESCRIPTION
## 概要
1つのウイスキーに対して紐付けられるフレーバーを3つまでに制限するバリデーションの追加、及び日本語化対応。
## 確認方法
`FileChanges`とIssue #32 を参照
## 影響範囲
- `model/whiskey.rb`
- `model.ja.yml`
## コメント
実装自体は30mで終わったがQiita記事を書いていたら結局3時間ほどかかってしまった。
書いたQiita記事→https://qiita.com/tarakish/items/4a6472e7ecb0e07f2e6a
## Close Issues
Close #32 